### PR TITLE
Integrate multi-schema support adjustments from Mark Armendariz's fork

### DIFF
--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -29,16 +29,15 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
         // Register GraphQLService
         $this->graphQLService = $this->app->make( GraphQLService::class );
 
-        // Retrieve the current request instance
-        $request = $this->app->make( Request::class );
-
         // Register ASTCacheService
-        $this->app->singleton( ASTCache::class, function ( $app ) use ( $request ) {
+        $this->app->singleton( ASTCache::class, function ($app) {
+            $request = $app->make( Request::class );
             return new ASTCacheService( $app['config'], $this->graphQLService, $request );
         });
 
         // Register SchemaSourceProvider
-        $this->app->singleton( SchemaSourceProvider::class, function () use ( $request )  {
+        $this->app->singleton( SchemaSourceProvider::class, function ($app)  {
+            $request = $app->make( Request::class );
             $schemaPath = $this->graphQLService->getSchemaPath( $request->getPathInfo() );
             return new SchemaStitcher( $schemaPath );
         });


### PR DESCRIPTION
This pull request merges valuable contributions from [Mark Armendariz's GitHub account](https://github.com/enobrev) and his fork at [Elomi-inc](https://github.com/Elomi-inc) to enhance multi-schema support for ```yakovenko/laravel-lighthouse-graphql-multi-schema```.

**Key Changes**
-  ****Modified request handling:**** Improved compatibility with PHPUnit tests by addressing an issue where the request URI returned ```/``` instead of the expected ```/user-graphql``` (or similar). In a multi-schema GraphQL setup, each schema is tied to a specific endpoint (e.g., ```/web-graphql```, ```/admin-graphql```), so ensuring the correct endpoint is essential for selecting the appropriate schema during tests.
 - ****Updated routing setup:**** Adjusted the routing to align with Lighthouse's standard approach, ensuring consistent routing behavior and reliability across various setups.

These adjustments improve compatibility with Laravel 11, PHP 8.3, and streamline PHPUnit testing. Special thanks to Mark for identifying and implementing these solutions, which enhance the package’s usability across diverse environments.