### PR TITLE
feat: adapt multi-schema cache for Laravel Octane support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,10 @@
 - Laravel           : ^9.0 || ^10.0 || ^11.0 || ^12.0
 - Nuwave Lighthouse : ^6.0
 
-> **New in v2.0.0:** Full support for Laravel Octane and long-lived workers!
+### 🚀 What’s New in v2.0.0
 
-## 🚀 Octane & Worker Support
-
-**Since v2.0.0, this package is fully compatible with [Laravel Octane](https://laravel.com/docs/12.x/octane) and any long-lived worker environment (Swoole, RoadRunner, etc).**
-
-- `ASTCache` and `SchemaSourceProvider` are now registered with `bind` instead of `singleton` to ensure a fresh context per request.
-- This change is required for correct schema resolution and cache separation in Octane/Swoole/RoadRunner.
-
-### ⚠️ Breaking Change
-
-If you relied on `ASTCache` or `SchemaSourceProvider` being singletons, please update your code accordingly.  
-**From v2.0.0, these services are no longer singletons!**
-
-#### How to upgrade
-
-- Clear all caches:  
-  `php artisan config:clear && php artisan cache:clear && php artisan lighthouse:clear-cache`
-- Make sure you do not store the request object in any singleton or static property.
-- Always use the `request()` helper to access the current request in your code.
-
----
+- Full support for **Laravel Octane** and **long-lived workers** (Swoole, RoadRunner, etc).  
+  _See [release notes](https://github.com/as-yakovenko/laravel-lighthouse-graphql-multi-schema/releases/tag/v2.0.0) for technical details._
 
 ### Install the Package
 
@@ -166,28 +148,31 @@ example:
 example:
 ```
 /graphql
-├── web
-│   └── web.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation, login, registration )
-│   └── models ( Type, Enum, Input )
-│   │	└── User.graphql
-│   │	└── Order.graphql
-│   │	└── Product.graphql
+│── models ( Type, Enum, Input )  # Shared types, enums, inputs
+│   └── User.graphql
+│   └── Order.graphql
+│   └── Product.graphql
+│
+├── v1 # Entry point for v1, imports shared models and v1-specific queries/mutations
+│   └── v1.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation, login, registration )
 │   └── request ( Query, Mutation )
 │   	└── user_request.graphql ( meUpdate, me )
 │   	└── order_request.graphql  ( meOrders )
 │   	└── product_request.graphql ( products, product )
-├── crm
-│   └── crm.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation )
+│
+├── v2 # Entry point for v2, can import the same models and only add/override what's new
+│   └── v2.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation )
 │   └── request ( Query, Mutation )
-│   │	└── order_request.graphql  ( orders, order )
-│   └── models ( Type, Enum, Input )
-├── adm
-│   └── adm.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation )
+│    	└── order_request.graphql  ( orders, order )
+│
+├── v3 # Entry point for v3, can import the same models and only add/override what's new
+│   └── v3.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation )
 │   └── request ( Query, Mutation )
 │   │	└── user_request.graphql ( userCreate, userUpdate, userDelete, user, me, users )
 │   │	└── order_request.graphql  ( orders, orders, orderUpdate, orderDelete, orderCreate )
 │   │	└── product_request.graphql ( products, product, productUpdate, productDelete, productCreate )
-│   └── models ( Type, Enum, Input )
+│   └── models ( Type, Enum, Input ) # if you need to personalize models according to the type of scheme
+│
 └── api
     └── api.graphql ( #import /models/*.graphql, #import /request/*.graphql, general scalar, query and mutation )
     └── request ( Query, Mutation )

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -41,14 +41,14 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
             return new SchemaASTCache(
                 $app['config'],
                 $app->make( GraphQLSchemaConfig::class ),
-                $app->make('request')
+                request()
             );
         });
 
         // Register SchemaSourceProvider bind using SchemaStitcher
         $this->app->bind( SchemaSourceProvider::class, function ( $app ) {
             return new SchemaStitcher(
-                $app->make( GraphQLSchemaConfig::class)->getPath( $app->make('request') )
+                $app->make( GraphQLSchemaConfig::class)->getPath( request() )
             );
         });
 

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -35,8 +35,9 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
             return new GraphQLRouteRegister();
         });
 
-        // Register SchemaASTCache with dependency on GraphQLSchemaConfig
-        $this->app->singleton( ASTCache::class, function ( $app ) {
+        // Register SchemaASTCache as bind (not singleton) to make it Octane-compatible
+        // This ensures a fresh instance per request with current request context
+        $this->app->bind( ASTCache::class, function ( $app ) {
             return new SchemaASTCache(
                 $app['config'],
                 $app->make( GraphQLSchemaConfig::class ),

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -40,8 +40,7 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
         $this->app->bind( ASTCache::class, function ( $app ) {
             return new SchemaASTCache(
                 $app['config'],
-                $app->make( GraphQLSchemaConfig::class ),
-                request()
+                $app->make( GraphQLSchemaConfig::class )
             );
         });
 

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -25,8 +25,8 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Register GraphQLSchemaConfig singleton
-        $this->app->singleton( GraphQLSchemaConfig::class, function () {
+        // Register GraphQLSchemaConfig bind
+        $this->app->bind( GraphQLSchemaConfig::class, function () {
             return new GraphQLSchemaConfig();
         });
 
@@ -39,13 +39,16 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
         $this->app->singleton( ASTCache::class, function ( $app ) {
             return new SchemaASTCache(
                 $app['config'],
-                $app->make( GraphQLSchemaConfig::class )
+                $app->make( GraphQLSchemaConfig::class ),
+                $app->make('request')
             );
         });
 
-        // Register SchemaSourceProvider singleton using SchemaStitcher
-        $this->app->singleton( SchemaSourceProvider::class, function ( $app ) {
-            return new SchemaStitcher( $app->make( GraphQLSchemaConfig::class )->getPath() );
+        // Register SchemaSourceProvider bind using SchemaStitcher
+        $this->app->bind( SchemaSourceProvider::class, function ( $app ) {
+            return new SchemaStitcher(
+                $app->make( GraphQLSchemaConfig::class)->getPath( $app->make('request') )
+            );
         });
 
         // Merge package configuration with application configuration

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -47,7 +47,7 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
         // Register SchemaSourceProvider bind using SchemaStitcher
         $this->app->bind( SchemaSourceProvider::class, function ( $app ) {
             return new SchemaStitcher(
-                $app->make( GraphQLSchemaConfig::class)->getPath( request() )
+                $app->make( GraphQLSchemaConfig::class )->getPath( request() )
             );
         });
 

--- a/src/Services/GraphQLSchemaConfig.php
+++ b/src/Services/GraphQLSchemaConfig.php
@@ -85,7 +85,6 @@ class GraphQLSchemaConfig
 
         return match ( $key ) {
             'key'                 => config('lighthouse.route.uri') === $requestPath ? 'default' : null,
-            'route_uri'           => config('lighthouse.route.uri'),
             'schema_path'         => config('lighthouse.schema_path'),
             'schema_cache_path'   => config('lighthouse.schema_cache.path'),
             'schema_cache_enable' => config('lighthouse.schema_cache.enable', false),

--- a/src/Services/GraphQLSchemaConfig.php
+++ b/src/Services/GraphQLSchemaConfig.php
@@ -6,125 +6,90 @@ use Illuminate\Http\Request;
 
 class GraphQLSchemaConfig
 {
-    protected Request $request;
-
     /**
      * The multi-schema configurations.
      *
-     * This property holds the configuration for multiple GraphQL schemas, 
-     * as defined in the 'lighthouse-multi-schemas' configuration file.
-     *
-     * @var array<string, array> Array of schema configurations keyed by schema name.
+     * @var array<string, array>
      */
     public array $multiSchemas;
 
-    /**
-     * The key of the current schema determined from the request path.
-     *
-     * @var string|null
-     */
-    protected ?string $key = null;
-
-    /**
-     * The path to the schema file for the current schema.
-     *
-     * @var string|null
-     */
-    protected ?string $path = null;
-
-    /**
-     * The path to the cache file for the current schema.
-     *
-     * @var string|null
-     */
-    protected ?string $cachePath = null;
-
-    /**
-     * Whether caching is enabled for the current schema.
-     *
-     * @var bool|null
-     */
-    protected ?bool $cacheEnabled = null;
-
-    /**
-     * GraphQLSchemaConfig constructor.
-     *
-     * Initializes the multiSchemas property by fetching the configuration 
-     * from the 'lighthouse-multi-schemas' setting and sets the current schema context
-     * based on the incoming request.
-     */
     public function __construct()
     {
-        $this->request      = request();
         $this->multiSchemas = config('lighthouse-multi-schema.multi_schemas', []);
-        $this->initializeCurrentSchema();
-    }
-
-    /**
-     * Initialize the current schema based on the request path.
-     *
-     * Determines the schema key, schema file path, cache file path,
-     * and whether caching is enabled, based on the incoming request.
-     *
-     * @return void
-     */
-    protected function initializeCurrentSchema(): void
-    {
-        $requestPath = $this->request->getPathInfo();
-
-        foreach ( $this->multiSchemas as $schemaKey => $schemaConfig ) {
-            if ( $schemaConfig['route_uri'] === $requestPath ) {
-                $this->key          = $schemaKey;
-                $this->path         = $schemaConfig['schema_path'] ?? null;
-                $this->cachePath    = $schemaConfig['schema_cache_path'] ?? null;
-                $this->cacheEnabled = $schemaConfig['schema_cache_enable'] ?? false;
-                return;
-            }
-        }
-
-        $this->key          = config('lighthouse.route.uri') === $requestPath ? 'default' : null;
-        $this->path         = config('lighthouse.schema_path');
-        $this->cachePath    = config('lighthouse.schema_cache.path');
-        $this->cacheEnabled = config('lighthouse.schema_cache.enable', false);
     }
 
     /**
      * Get the key for the current GraphQL schema.
      *
-     * @return string|null The key for the current schema, or null if no match is found.
+     * @param Request $request
+     * @return string|null
      */
-    public function getKey(): ?string
+    public function getKey( Request $request ): ?string
     {
-        return $this->key;
+        return $this->getSchemaConfig( $request, 'key' );
     }
 
     /**
      * Get the path to the GraphQL schema file.
      *
-     * @return ?string The schema file path for the current schema or null if not set.
+     * @param Request $request
+     * @return string|null
      */
-    public function getPath(): ?string
+    public function getPath( Request $request ): ?string
     {
-        return $this->path;
+        return $this->getSchemaConfig( $request, 'schema_path' );
     }
 
     /**
      * Get the path to the GraphQL schema cache file.
      *
-     * @return ?string The cache file path for the current schema or null if not set.
+     * @param Request $request
+     * @return string|null
      */
-    public function getCachePath(): ?string
+    public function getCachePath( Request $request ): ?string
     {
-        return $this->cachePath;
+        return $this->getSchemaConfig( $request, 'schema_cache_path' );
     }
 
     /**
      * Check if schema caching is enabled.
      *
-     * @return bool True if caching is enabled, false otherwise.
+     * @param Request $request
+     * @return bool
      */
-    public function isCacheEnabled(): bool
+    public function isCacheEnabled( Request $request ): bool
     {
-        return $this->cacheEnabled;
+        return (bool) $this->getSchemaConfig( $request, 'schema_cache_enable' );
+    }
+
+    /**
+     * Universal getter for schema config values by key.
+     *
+     * @param Request $request
+     * @param string $key
+     * @return mixed
+     */
+    protected function getSchemaConfig( Request $request, string $key ): mixed
+    {
+        $requestPath = $request->getPathInfo();
+
+        foreach ( $this->multiSchemas as $schemaKey => $schemaConfig ) {
+            if ( $schemaConfig['route_uri'] === $requestPath ) {
+                if ( $key === 'key' ) {
+                    return $schemaKey;
+                } else {
+                    return $schemaConfig[$key] ?? null;
+                }
+            }
+        }
+
+        return match ( $key ) {
+            'key'                 => config('lighthouse.route.uri') === $requestPath ? 'default' : null,
+            'route_uri'           => config('lighthouse.route.uri'),
+            'schema_path'         => config('lighthouse.schema_path'),
+            'schema_cache_path'   => config('lighthouse.schema_cache.path'),
+            'schema_cache_enable' => config('lighthouse.schema_cache.enable', false),
+            default => null,
+        };
     }
 }

--- a/src/Services/SchemaASTCache.php
+++ b/src/Services/SchemaASTCache.php
@@ -13,18 +13,28 @@ use Illuminate\Container\Container;
 class SchemaASTCache extends ASTCache
 {
     protected GraphQLSchemaConfig $graphQLSchemaConfig;
-    protected Request $request;
 
     /**
      * @param ConfigRepository $config
      * @param GraphQLSchemaConfig $graphQLSchemaConfig
-     * @param Request $request
+     * @param Request $request - Only used for initial setup, not stored
      */
     public function __construct( ConfigRepository $config, GraphQLSchemaConfig $graphQLSchemaConfig, Request $request )
     {
         parent::__construct( $config );
         $this->graphQLSchemaConfig = $graphQLSchemaConfig;
-        $this->request = $request;
+        // Note: Not storing $request to make it Octane-compatible
+    }
+
+    /**
+     * Get the current request dynamically from the container.
+     * This ensures we always get the current request in Octane environments.
+     *
+     * @return Request
+     */
+    protected function getCurrentRequest(): Request
+    {
+        return Container::getInstance()->make('request');
     }
 
     /**
@@ -34,7 +44,7 @@ class SchemaASTCache extends ASTCache
      */
     protected function getCurrentCachePath(): string
     {
-        return $this->graphQLSchemaConfig->getCachePath( $this->request ) ?? $this->path;
+        return $this->graphQLSchemaConfig->getCachePath( $this->getCurrentRequest() ) ?? $this->path;
     }
 
     /**
@@ -44,7 +54,7 @@ class SchemaASTCache extends ASTCache
      */
     public function isEnabled(): bool
     {
-        return $this->graphQLSchemaConfig->isCacheEnabled( $this->request ) ?? false;
+        return $this->graphQLSchemaConfig->isCacheEnabled( $this->getCurrentRequest() ) ?? false;
     }
 
     /**

--- a/src/Services/SchemaASTCache.php
+++ b/src/Services/SchemaASTCache.php
@@ -4,38 +4,102 @@ namespace Yakovenko\LighthouseGraphqlMultiSchema\Services;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Nuwave\Lighthouse\Schema\AST\ASTCache;
+use Illuminate\Http\Request;
+use Nuwave\Lighthouse\Schema\AST\DocumentAST;
+use Illuminate\Filesystem\Filesystem;
+use Nuwave\Lighthouse\Exceptions\InvalidSchemaCacheContentsException;
+use Illuminate\Container\Container;
 
 class SchemaASTCache extends ASTCache
 {
-    protected bool $cacheEnable;
+    protected GraphQLSchemaConfig $graphQLSchemaConfig;
+    protected Request $request;
 
     /**
-     * Constructor.
-     *
-     * Initializes the ASTCacheService by setting the cache path and cache enable
-     * flag based on the current request URI using the provided graphQLSchemaConfig.
-     *
-     * @param ConfigRepository $config The configuration repository instance.
-     * @param GraphQLSchemaConfig $graphQLSchemaConfig The GraphQL service instance.
+     * @param ConfigRepository $config
+     * @param GraphQLSchemaConfig $graphQLSchemaConfig
+     * @param Request $request
      */
-    public function __construct( ConfigRepository $config, GraphQLSchemaConfig $graphQLSchemaConfig )
+    public function __construct( ConfigRepository $config, GraphQLSchemaConfig $graphQLSchemaConfig, Request $request )
     {
         parent::__construct( $config );
-
-        $this->path        = $graphQLSchemaConfig->getCachePath();
-        $this->cacheEnable = $graphQLSchemaConfig->isCacheEnabled();
+        $this->graphQLSchemaConfig = $graphQLSchemaConfig;
+        $this->request = $request;
     }
 
     /**
-     * Check if schema caching is enabled.
+     * Get the current cache path for the request.
      *
-     * This method overrides the parent isEnabled method to return the caching status
-     * based on the current request URI.
+     * @return string
+     */
+    protected function getCurrentCachePath(): string
+    {
+        return $this->graphQLSchemaConfig->getCachePath( $this->request ) ?? $this->path;
+    }
+
+    /**
+     * Check if the cache is enabled for the current request.
      *
-     * @return bool True if caching is enabled, false otherwise.
+     * @return bool
      */
     public function isEnabled(): bool
     {
-        return $this->cacheEnable;
+        return $this->graphQLSchemaConfig->isCacheEnabled( $this->request ) ?? false;
     }
+
+    /**
+     * Set the document AST in the cache.
+     *
+     * @param DocumentAST $documentAST
+     * @return void
+     */
+    public function set( DocumentAST $documentAST ): void
+    {
+        $variable = var_export( $documentAST->toArray(), true );
+        $this->filesystem()->put(
+            $this->getCurrentCachePath(),
+            /** @lang PHP */ "<?php return {$variable};"
+        );
+    }
+
+    /** @param  callable(): DocumentAST  $build */
+    public function fromCacheOrBuild( callable $build ): DocumentAST
+    {
+        $path = $this->getCurrentCachePath();
+
+        if ( $this->filesystem()->exists( $path ) ) {
+            $ast = require $path;
+            if ( !is_array( $ast ) ) {
+                throw new InvalidSchemaCacheContentsException( $path, $ast );
+            }
+
+            return DocumentAST::fromArray( $ast );
+        }
+
+        $documentAST = $build();
+        $this->set( $documentAST );
+
+        return $documentAST;
+    }
+
+    /**
+     * Clear the cache for the current request.
+     *
+     * @return void
+     */
+    public function clear(): void
+    {
+        $this->filesystem()->delete( $this->getCurrentCachePath() );
+    }
+
+    /**
+     * Get the filesystem instance.
+     *
+     * @return Filesystem
+     */
+    protected function filesystem(): Filesystem
+    {
+        return Container::getInstance()->make( Filesystem::class );
+    }
+
 }

--- a/src/Services/SchemaASTCache.php
+++ b/src/Services/SchemaASTCache.php
@@ -34,7 +34,7 @@ class SchemaASTCache extends ASTCache
      */
     protected function getCurrentRequest(): Request
     {
-        return Container::getInstance()->make('request');
+        return request();
     }
 
     /**

--- a/src/Services/SchemaASTCache.php
+++ b/src/Services/SchemaASTCache.php
@@ -17,13 +17,11 @@ class SchemaASTCache extends ASTCache
     /**
      * @param ConfigRepository $config
      * @param GraphQLSchemaConfig $graphQLSchemaConfig
-     * @param Request $request - Only used for initial setup, not stored
      */
-    public function __construct( ConfigRepository $config, GraphQLSchemaConfig $graphQLSchemaConfig, Request $request )
+    public function __construct( ConfigRepository $config, GraphQLSchemaConfig $graphQLSchemaConfig )
     {
         parent::__construct( $config );
         $this->graphQLSchemaConfig = $graphQLSchemaConfig;
-        // Note: Not storing $request to make it Octane-compatible
     }
 
     /**


### PR DESCRIPTION
- Refactored the package to a stateless architecture for compatibility with Octane and long-lived workers
- Cache path for each schema is now dynamically resolved per request 
- Fixed imports and method signatures for full compatibility with Lighthouse Temporarily implemented a workaround for dynamic schema cache path (until supported by Lighthouse core) 
- Updated service bindings in the service provider