### PR TITLE
fix: SchemaKeyedContainer for Octane/Swoole performance

### DIFF
--- a/src/Commands/LighthouseClearCacheCommand.php
+++ b/src/Commands/LighthouseClearCacheCommand.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Yakovenko\LighthouseGraphqlMultiSchema\Commands;
 
@@ -7,6 +9,7 @@ use Illuminate\Filesystem\Filesystem;
 use Nuwave\Lighthouse\Schema\AST\ASTCache;
 use Symfony\Component\Console\Input\InputArgument;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\GraphQLSchemaConfig;
+use Yakovenko\LighthouseGraphqlMultiSchema\Services\SchemaKeyedContainer;
 
 /**
  * Class LighthouseClearCacheCommand
@@ -40,11 +43,8 @@ class LighthouseClearCacheCommand extends Command
 
     /**
      * Create a new command instance.
-     *
-     * @param Filesystem $filesystem
-     * @param GraphQLSchemaConfig $graphQLSchemaConfig
      */
-    public function __construct( protected Filesystem $filesystem, protected GraphQLSchemaConfig $graphQLSchemaConfig )
+    public function __construct(protected Filesystem $filesystem, protected GraphQLSchemaConfig $graphQLSchemaConfig)
     {
         parent::__construct();
     }
@@ -54,32 +54,25 @@ class LighthouseClearCacheCommand extends Command
      *
      * If a schema name is provided as an argument, clear the cache for that schema.
      * Otherwise, clear all schema caches.
-     *
-     * @param ASTCache $cache
-     * @return void
      */
-    public function handle( ASTCache $cache ): void
+    public function handle(ASTCache $cache): void
     {
-        $schemaName = $this->argument( 'schema' );
+        $schemaName = $this->argument('schema');
+        $keyedContainer = app(SchemaKeyedContainer::class);
 
-        if ( $schemaName ) {
-
-            if ( $schemaName === 'all' ) {
-
-                $this->clearAllSchemaCaches( $cache );
-                $this->info( 'All GraphQL AST schema caches deleted.' );
-
+        if ($schemaName) {
+            if ($schemaName === 'all') {
+                $this->clearAllSchemaCaches($cache);
+                $keyedContainer->flushAll();
+                $this->info('All GraphQL AST schema caches deleted.');
             } else {
-
-                $this->clearSchemaCache( $schemaName );
-
+                $this->clearSchemaCache($schemaName);
+                $keyedContainer->flushSchema($schemaName);
             }
-
         } else {
-
             $cache->clear();
-            $this->info( 'Default GraphQL schema cache removed.' );
-
+            $keyedContainer->flushSchema('default');
+            $this->info('Default GraphQL schema cache removed.');
         }
     }
 
@@ -87,54 +80,38 @@ class LighthouseClearCacheCommand extends Command
      * Clear the cache for a specific schema.
      *
      * @param string $schemaName The name of the schema to clear the cache for.
-     * @return void
      */
-    protected function clearSchemaCache( string $schemaName ): void
+    protected function clearSchemaCache(string $schemaName): void
     {
         $multiSchemas = $this->graphQLSchemaConfig->multiSchemas;
 
-        if ( isset( $multiSchemas[$schemaName] ) ) {
-
+        if (isset($multiSchemas[$schemaName])) {
             $cachePath = $multiSchemas[$schemaName]['schema_cache_path'] ?? null;
 
-            if ( $cachePath && $this->filesystem->exists( $cachePath ) ) {
-
-                $this->filesystem->delete( $cachePath );
-                $this->info( "GraphQL AST schema cache for '{$schemaName}' deleted." );
-
+            if ($cachePath && $this->filesystem->exists($cachePath)) {
+                $this->filesystem->delete($cachePath);
+                $this->info("GraphQL AST schema cache for '{$schemaName}' deleted.");
             } else {
-
-                $this->warn( "Cache file for '{$schemaName}' not found." );
-
+                $this->warn("Cache file for '{$schemaName}' not found.");
             }
-
         } else {
-
-            $this->warn( "Schema '{$schemaName}' not configured." );
-
+            $this->warn("Schema '{$schemaName}' not configured.");
         }
     }
 
     /**
      * Clear the cache for all schemas and the default schema.
-     *
-     * @param ASTCache $cache
-     * @return void
      */
-    protected function clearAllSchemaCaches( ASTCache $cache ): void
+    protected function clearAllSchemaCaches(ASTCache $cache): void
     {
         $multiSchemas = $this->graphQLSchemaConfig->multiSchemas;
 
-        foreach ( $multiSchemas as $schemaConfig ) {
-
+        foreach ($multiSchemas as $schemaConfig) {
             $cachePath = $schemaConfig['schema_cache_path'] ?? null;
 
-            if ( $cachePath && $this->filesystem->exists( $cachePath) ) {
-
-                $this->filesystem->delete( $cachePath );
-
+            if ($cachePath && $this->filesystem->exists($cachePath)) {
+                $this->filesystem->delete($cachePath);
             }
-
         }
 
         // Clear the default schema cache

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -18,72 +18,83 @@ use Yakovenko\LighthouseGraphqlMultiSchema\Commands\PublishConfigCommand;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\GraphQLRouteRegister;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\GraphQLSchemaConfig;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\SchemaASTCache;
+use Yakovenko\LighthouseGraphqlMultiSchema\Services\SchemaKeyedContainer;
 
 class LighthouseMultiSchemaServiceProvider extends ServiceProvider
 {
     /**
      * Register services.
      *
-     * This method registers various services and configurations required for
-     * the Lighthouse GraphQL multi-schema functionality. It includes registering
-     * GraphQLSchemaConfig, GraphQLRouteRegister, SchemaASTCache, SchemaSourceProvider,
-     * and configuration files. Additionally, it registers commands for publishing
-     * configuration and clearing the cache.
-     *
      * @return void
      */
     public function register()
     {
-        // Register GraphQLSchemaConfig as scoped (one per request, flushed between Octane requests)
-        $this->app->scoped( GraphQLSchemaConfig::class, function () {
+        // GraphQLSchemaConfig is stateless (reads config + request path), safe as singleton
+        $this->app->singleton(GraphQLSchemaConfig::class, function () {
             return new GraphQLSchemaConfig();
         });
 
         // Register GraphQLRouteRegister without dependency injection
-        $this->app->singleton( GraphQLRouteRegister::class, function () {
+        $this->app->singleton(GraphQLRouteRegister::class, function () {
             return new GraphQLRouteRegister();
         });
 
-        // Register SchemaASTCache as scoped (one per request, flushed between Octane requests)
-        $this->app->scoped( ASTCache::class, function ( $app ) {
-            return new SchemaASTCache(
-                $app['config'],
-                $app->make( GraphQLSchemaConfig::class )
+        // SchemaKeyedContainer persists across ALL requests in the Octane worker.
+        // It caches built service instances keyed by schema identifier so that
+        // each schema's services are constructed exactly once per worker lifetime.
+        $this->app->singleton(SchemaKeyedContainer::class, function () {
+            return new SchemaKeyedContainer();
+        });
+
+        // ASTCache — scoped() so the closure runs once per request (not on every make() call).
+        // SchemaKeyedContainer returns the cached instance, so the expensive construction
+        // only happens on the very first request for each schema.
+        $this->app->scoped(ASTCache::class, function ($app) {
+            return $app->make(SchemaKeyedContainer::class)->resolve(
+                ASTCache::class,
+                $this->resolveSchemaKey(),
+                fn () => new SchemaASTCache(
+                    $app['config'],
+                    $app->make(GraphQLSchemaConfig::class)
+                )
             );
         });
 
-        // Register SchemaSourceProvider as scoped (one per request, flushed between Octane requests)
-        $this->app->scoped( SchemaSourceProvider::class, function ( $app ) {
-            return new SchemaStitcher(
-                $app->make( GraphQLSchemaConfig::class )->getPath( request() )
+        // SchemaSourceProvider — same pattern: scoped() + keyed cache
+        $this->app->scoped(SchemaSourceProvider::class, function ($app) {
+            return $app->make(SchemaKeyedContainer::class)->resolve(
+                SchemaSourceProvider::class,
+                $this->resolveSchemaKey(),
+                fn () => new SchemaStitcher(
+                    $app->make(GraphQLSchemaConfig::class)->getPath(request())
+                )
             );
         });
 
         // Merge package configuration with application configuration
         $this->mergeConfigFrom(
-            __DIR__ . '/lighthouse-multi-schema.php', 'lighthouse-multi-schema'
+            __DIR__ . '/lighthouse-multi-schema.php',
+            'lighthouse-multi-schema'
         );
 
         // Register custom commands
-        $this->commands( [
+        $this->commands([
             PublishConfigCommand::class,
             MultiSchemaIdeHelperCommand::class,
-            MultiSchemaValidateCommand::class
-        ] );
+            MultiSchemaValidateCommand::class,
+        ]);
 
         // Force override of lighthouse:clear-cache command
-        $this->app->singleton( 'command.lighthouse.clear-cache', function ( $app ) {
+        $this->app->singleton('command.lighthouse.clear-cache', function ($app) {
             return new LighthouseClearCacheCommand(
                 $app['files'],
-                $app->make( GraphQLSchemaConfig::class )
+                $app->make(GraphQLSchemaConfig::class)
             );
         });
     }
 
     /**
      * Bootstrap services.
-     *
-     * Publishes the configuration file and registers GraphQL routes.
      *
      * @return void
      */
@@ -94,22 +105,76 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
             __DIR__ . '/lighthouse-multi-schema.php' => config_path('lighthouse-multi-schema.php'),
         ], 'config');
 
-        // Override Lighthouse's singletons with scoped bindings for Octane/Swoole compatibility.
-        // Lighthouse registers GraphQL, SchemaBuilder, ASTBuilder, DirectiveLocator, and TypeRegistry
-        // as singletons which cache schema state. Under Octane, these persist across requests,
-        // breaking multi-schema switching. Scoped bindings are flushed between requests automatically.
-        $this->app->scoped( GraphQL::class );
-        $this->app->scoped( SchemaBuilder::class );
-        $this->app->scoped( ASTBuilder::class );
-        $this->app->scoped( DirectiveLocator::class );
-        $this->app->scoped( TypeRegistry::class );
+        // Override Lighthouse's singletons with scoped() + SchemaKeyedContainer.
+        //
+        // ## Why plain singleton() breaks multi-schema under Octane
+        //
+        // Lighthouse registers these as singletons. Under Octane/Swoole, singletons
+        // persist across requests, caching the first request's schema state forever.
+        //
+        // ## Why pure scoped() was slow
+        //
+        // scoped() rebuilds ALL services from scratch every request (schema parsing,
+        // AST building, directive registration, type resolution). This negates
+        // Swoole's persistent-worker advantage entirely.
+        //
+        // ## Why bind() was also slow
+        //
+        // bind() runs the closure on EVERY $app->make() call, not just once per
+        // request. These services are resolved many times through DI chains within
+        // a single request, multiplying the overhead.
+        //
+        // ## Current approach: scoped() + SchemaKeyedContainer
+        //
+        // - scoped() ensures the closure runs exactly ONCE per request per service
+        //   (subsequent make() calls in the same request return the cached result)
+        // - SchemaKeyedContainer (a true singleton) caches built instances keyed by
+        //   schema, so $app->build() runs exactly ONCE per schema per worker lifetime
+        //
+        // Per-request cost: 1 closure call × 5 services = 5 hash lookups (negligible)
+        // Memory cost: N sets of services where N = number of schemas (typically 2-3)
+        $schemaKeyedServices = [
+            GraphQL::class,
+            SchemaBuilder::class,
+            ASTBuilder::class,
+            DirectiveLocator::class,
+            TypeRegistry::class,
+        ];
+
+        foreach ($schemaKeyedServices as $service) {
+            $this->app->scoped($service, function ($app) use ($service) {
+                return $app->make(SchemaKeyedContainer::class)->resolve(
+                    $service,
+                    $this->resolveSchemaKey(),
+                    fn () => $app->build($service)
+                );
+            });
+        }
 
         // Register GraphQL routes by resolving GraphQLRouteRegister from the container
-        $this->app->make( GraphQLRouteRegister::class )->registerGraphQLRoutes();
+        $this->app->make(GraphQLRouteRegister::class)->registerGraphQLRoutes();
 
         // Register overridden command
-        if ( $this->app->runningInConsole() ) {
-            $this->commands( ['command.lighthouse.clear-cache'] );
+        if ($this->app->runningInConsole()) {
+            $this->commands(['command.lighthouse.clear-cache']);
+        }
+    }
+
+    /**
+     * Resolve the current schema key from the request path.
+     *
+     * Falls back to 'default' when running in console or when no schema matches.
+     */
+    protected function resolveSchemaKey(): string
+    {
+        if ($this->app->runningInConsole()) {
+            return 'default';
+        }
+
+        try {
+            return $this->app->make(GraphQLSchemaConfig::class)->getKey(request()) ?? 'default';
+        } catch (\Throwable) {
+            return 'default';
         }
     }
 }

--- a/src/LighthouseMultiSchemaServiceProvider.php
+++ b/src/LighthouseMultiSchemaServiceProvider.php
@@ -3,14 +3,19 @@
 namespace Yakovenko\LighthouseGraphqlMultiSchema;
 
 use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\GraphQL;
+use Nuwave\Lighthouse\Schema\AST\ASTBuilder;
+use Nuwave\Lighthouse\Schema\AST\ASTCache;
+use Nuwave\Lighthouse\Schema\DirectiveLocator;
+use Nuwave\Lighthouse\Schema\SchemaBuilder;
 use Nuwave\Lighthouse\Schema\Source\SchemaSourceProvider;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
-use Nuwave\Lighthouse\Schema\AST\ASTCache;
+use Nuwave\Lighthouse\Schema\TypeRegistry;
+use Yakovenko\LighthouseGraphqlMultiSchema\Commands\LighthouseClearCacheCommand;
+use Yakovenko\LighthouseGraphqlMultiSchema\Commands\PublishConfigCommand;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\GraphQLRouteRegister;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\GraphQLSchemaConfig;
 use Yakovenko\LighthouseGraphqlMultiSchema\Services\SchemaASTCache;
-use Yakovenko\LighthouseGraphqlMultiSchema\Commands\LighthouseClearCacheCommand;
-use Yakovenko\LighthouseGraphqlMultiSchema\Commands\PublishConfigCommand;
 
 class LighthouseMultiSchemaServiceProvider extends ServiceProvider
 {
@@ -27,8 +32,8 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Register GraphQLSchemaConfig bind
-        $this->app->bind( GraphQLSchemaConfig::class, function () {
+        // Register GraphQLSchemaConfig as scoped (one per request, flushed between Octane requests)
+        $this->app->scoped( GraphQLSchemaConfig::class, function () {
             return new GraphQLSchemaConfig();
         });
 
@@ -37,17 +42,16 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
             return new GraphQLRouteRegister();
         });
 
-        // Register SchemaASTCache as bind (not singleton) to make it Octane-compatible
-        // This ensures a fresh instance per request with current request context
-        $this->app->bind( ASTCache::class, function ( $app ) {
+        // Register SchemaASTCache as scoped (one per request, flushed between Octane requests)
+        $this->app->scoped( ASTCache::class, function ( $app ) {
             return new SchemaASTCache(
                 $app['config'],
                 $app->make( GraphQLSchemaConfig::class )
             );
         });
 
-        // Register SchemaSourceProvider bind using SchemaStitcher
-        $this->app->bind( SchemaSourceProvider::class, function ( $app ) {
+        // Register SchemaSourceProvider as scoped (one per request, flushed between Octane requests)
+        $this->app->scoped( SchemaSourceProvider::class, function ( $app ) {
             return new SchemaStitcher(
                 $app->make( GraphQLSchemaConfig::class )->getPath( request() )
             );
@@ -83,6 +87,16 @@ class LighthouseMultiSchemaServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/lighthouse-multi-schema.php' => config_path('lighthouse-multi-schema.php'),
         ], 'config');
+
+        // Override Lighthouse's singletons with scoped bindings for Octane/Swoole compatibility.
+        // Lighthouse registers GraphQL, SchemaBuilder, ASTBuilder, DirectiveLocator, and TypeRegistry
+        // as singletons which cache schema state. Under Octane, these persist across requests,
+        // breaking multi-schema switching. Scoped bindings are flushed between requests automatically.
+        $this->app->scoped( GraphQL::class );
+        $this->app->scoped( SchemaBuilder::class );
+        $this->app->scoped( ASTBuilder::class );
+        $this->app->scoped( DirectiveLocator::class );
+        $this->app->scoped( TypeRegistry::class );
 
         // Register GraphQL routes by resolving GraphQLRouteRegister from the container
         $this->app->make( GraphQLRouteRegister::class )->registerGraphQLRoutes();

--- a/src/Services/SchemaKeyedContainer.php
+++ b/src/Services/SchemaKeyedContainer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Yakovenko\LighthouseGraphqlMultiSchema\Services;
+
+use Closure;
+
+/**
+ * Schema-keyed instance container for Lighthouse services.
+ *
+ * Stores resolved service instances keyed by schema identifier, allowing
+ * singleton-like performance while supporting multiple schemas under
+ * Laravel Octane (Swoole/RoadRunner).
+ *
+ * Each schema version gets its own isolated set of Lighthouse service instances.
+ * The first request to a schema builds and caches the services; subsequent
+ * requests to the same schema reuse them from memory.
+ *
+ * This avoids the performance penalty of scoped() bindings (which rebuild
+ * every request) while preventing the stale-state bug of plain singletons
+ * (which cache only one schema's state across all requests).
+ */
+class SchemaKeyedContainer
+{
+    /**
+     * Cached instances keyed by [serviceClass][schemaKey].
+     *
+     * @var array<class-string, array<string, object>>
+     */
+    protected array $instances = [];
+
+    /**
+     * Resolve a service instance for the given schema key.
+     *
+     * If an instance already exists for this service+schema combination,
+     * it is returned immediately (singleton behavior). Otherwise, the
+     * factory closure is called to build a new instance, which is then
+     * cached for future requests.
+     *
+     * @param class-string $service  The service class being resolved
+     * @param string       $schemaKey The schema identifier (e.g., 'default', 'schema1')
+     * @param Closure      $factory   Factory to build the instance if not cached
+     *
+     * @return object The resolved service instance
+     */
+    public function resolve(string $service, string $schemaKey, Closure $factory): object
+    {
+        if (! isset($this->instances[$service][$schemaKey])) {
+            $this->instances[$service][$schemaKey] = $factory();
+        }
+
+        return $this->instances[$service][$schemaKey];
+    }
+
+    /**
+     * Flush all cached instances for a specific schema.
+     *
+     * Useful for cache:clear or schema reload scenarios.
+     *
+     * @param string $schemaKey The schema identifier to flush
+     */
+    public function flushSchema(string $schemaKey): void
+    {
+        foreach ($this->instances as $service => $schemas) {
+            unset($this->instances[$service][$schemaKey]);
+        }
+    }
+
+    /**
+     * Flush all cached instances across all schemas.
+     *
+     * Useful for full cache clear or testing.
+     */
+    public function flushAll(): void
+    {
+        $this->instances = [];
+    }
+}


### PR DESCRIPTION
## Summary

Add `SchemaKeyedContainer` — a schema-keyed instance cache — to fix the performance regression introduced by the previous `scoped()` fix (#8).

## Background: the previous PR (#8)

PR #8 replaced Lighthouse's `singleton()` bindings with `scoped()` to fix multi-schema resolution under Octane. Under Octane, singletons persist across requests, so the first request's schema got cached forever — all subsequent requests received the wrong schema regardless of endpoint.

`scoped()` fixed correctness: each request got the right schema because Octane's `FlushTemporaryContainerInstances` listener automatically clears scoped bindings between requests.

## The problem with pure `scoped()`

While correct, pure `scoped()` **rebuilds every Lighthouse service from scratch on every request**:

- `GraphQL`, `SchemaBuilder`, `ASTBuilder`, `DirectiveLocator`, `TypeRegistry` — all reconstructed
- Schema parsing, AST building, directive registration, type resolution — all repeated
- `ASTCache` and `SchemaSourceProvider` — recreated

This negates Swoole's persistent-worker advantage entirely, making it **slower than PHP-FPM**.

## Solution: `scoped()` + `SchemaKeyedContainer`

`SchemaKeyedContainer` is a true `singleton()` that survives Octane request flushes. It caches service instances keyed by schema name.

**How it works:**
1. Services are still registered with `scoped()` — closure runs once per request
2. Inside the closure, `SchemaKeyedContainer::resolve()` checks if this schema's instance already exists
3. First request for a schema: builds the service, caches it. All subsequent requests: returns from cache instantly
4. Octane flushes the `scoped()` binding between requests, but `SchemaKeyedContainer` keeps the built instances

**Result:** services are built once per schema per worker lifetime, not once per request.

| Approach | Closure calls/request | Service builds | Correct schema? |
|----------|----------------------|----------------|----------------|
| `singleton()` (Lighthouse default) | 0 | Once total | No — only first schema |
| `scoped()` (PR #8) | 1 per service | Every request | Yes |
| **`scoped()` + `SchemaKeyedContainer`** (this PR) | **1 per service** | **Once per schema** | **Yes** |

## Files changed

- **New:** `src/Services/SchemaKeyedContainer.php` — keyed cache with `resolve()`, `flushSchema()`, `flushAll()`
- **Modified:** `src/LighthouseMultiSchemaServiceProvider.php` — all bindings now delegate to `SchemaKeyedContainer`; added `resolveSchemaKey()` helper
- **Modified:** `src/Commands/LighthouseClearCacheCommand.php` — flushes in-memory cache when clearing schema caches

## Backward compatibility

- No config changes required
- No breaking API changes
- PHP-FPM: no behavioral change (process dies after request anyway)
- `php artisan lighthouse:clear-cache` continues to work across all schemas