### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8",
         "nuwave/lighthouse": "^6.0",
-        "laravel/framework": "^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "haydenpierce/class-finder": "^0.4"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Widen `laravel/framework` version constraint from `^9.0 || ^10.0 || ^11.0 || ^12.0` to `^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0`

Laravel 13 was released and this change allows the package to be installed alongside it.

Made with [Cursor](https://cursor.com)