### PR TITLE
Allow haydenpierce/class-finder ^0.5 (Lighthouse v6.66+ requires it)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^8",
         "nuwave/lighthouse": "^6.0",
         "laravel/framework": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "haydenpierce/class-finder": "^0.4"
+        "haydenpierce/class-finder": "^0.4 || ^0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Why

Lighthouse v6.66+ requires \`haydenpierce/class-finder ^0.4 || ^0.5\`, so projects on a recent Lighthouse pull in \`class-finder 0.5.x\` transitively. This package's current constraint of \`^0.4\` excludes \`0.5.x\`, which makes upgrading from \`v2.1.x\` to \`v2.2.x\` impossible on those projects:

\`\`\`
yakovenko/laravel-lighthouse-graphql-multi-schema v2.2.3 requires haydenpierce/class-finder ^0.4
[your project] does not require haydenpierce/class-finder (but 0.5.3 is installed)
\`\`\`

## What

Widens the constraint to \`^0.4 || ^0.5\` to match Lighthouse's. The package's actual usage of \`HaydenPierce\\ClassFinder\\ClassFinder\` (in \`MultiSchemaIdeHelperCommand\` and friends) doesn't depend on any 0.5-specific behaviour, so the wider range is safe.

## Test plan

- [x] \`composer install\` resolves on a project running Lighthouse v6.66+ where \`class-finder 0.5.x\` is already installed.
- [x] \`lighthouse:multi-ide-helper\` and \`lighthouse:multi-validate-schema\` continue to work unchanged.